### PR TITLE
Addeded more configurable paramters

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ Also, there should be a copy of the latest epel repo in the local directory (cur
 
 * epel_release: name of the local epl file to use -- defaults to 'epel-release-latest-7.noarch.rpm'
 * download_node: url of the package diretory -- defaults to 'http://download-node-02.eng.bos.redhat.com/rcm-guest/ceph-drops/auto/rhscon-2-rhel-7-compose/latest-RHSCON-2-RHEL-7/compose/Installer/x86_64/os/Packages/'
+* brew_dir: directory containg brew rhceph image -- defaults to 'brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhceph'
+* docker_candidate: docker candidate -- defaults to 'ceph-2-rhel-7-docker-candidate-20170516014056'
+* automatically_do_everything: If true, docker pull, ansible-playbook and ceph -s test are done automatically -- defaults to true.  Set this to false if you want to edit yml files before running the playbook.

--- a/editansible.sh
+++ b/editansible.sh
@@ -3,6 +3,7 @@
 # Modify the yml files in /usr/share/ceph-ansible to work for the downstream
 # nodes.
 #
+docker_candidate=${docker_candidate:-'ceph-2-rhel-7-docker-candidate-20170516014056'}
 d=/usr/share/ceph-ansible
 sudo chown ubuntu:ubuntu ${d}
 sudo chown ubuntu:ubuntu ${d}/*
@@ -18,7 +19,7 @@ sed -i -e 's|#.*fetch_directory: .*|fetch_directory: ~/ceph-ansible-keys|' ${d}/
 sed -i -e 's|#.*monitor_interface: .*|monitor_interface: eno1|' ${d}/group_vars/all.yml
 sed -i -e 's|#public_network: .*|public_network: 10.8.128.0/21|' ${d}/group_vars/all.yml
 sed -i -e 's|#ceph_docker_image: .*|ceph_docker_image: rhceph|' ${d}/group_vars/all.yml
-sed -i -e 's|#ceph_docker_image_tag: .*|ceph_docker_image_tag: ceph-2-rhel-7-docker-candidate-20170516014056|' ${d}/group_vars/all.yml
+sed -i -e "s|#ceph_docker_image_tag: .*|ceph_docker_image_tag: ${docker_candidate}|" ${d}/group_vars/all.yml
 sed -i -e 's|#journal_size: .*|journal_size: 100|' ${d}/group_vars/all.yml
 sed -i -e 's|#docker: false|docker: true|' ${d}/group_vars/all.yml
 sed -i -e 's|#ceph_docker_registry: .*|ceph_docker_registry: brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888|' ${d}/group_vars/all.yml


### PR DESCRIPTION
Made brew_dir and docker_candidate environment varaibles so that brew
locations and docer candidates can be configured.

Added automatically_do_everything environment variable so that ceph is fully
deployed in one step.  Setting this variable to false allows a user to edit
yml files before running the playbook.

Redirected some stdout to /dev/null (rm -fr of files, for instance).

Make sure the ansible.log is readable and writeable by a non-root user.

Do not run ssh-keygen if a public key exists.

Signed-off-by: Warren Usui <wusui@magna002.ceph.redhat.com>